### PR TITLE
Fix typo in download database command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Currently, two databases are supported, NCBI's nr and the Genome Taxonomy Databa
 #### NCBI non-redundant protein database (nr)
 
 ```
-$ CAT_pack download -db nr -o path/to/nr_data_dir
+$ CAT_pack download --db nr -o path/to/nr_data_dir
 ```
 
 Will download the fasta file with the protein sequences, their mapping to a taxid, and the taxonomy information from NCBI's ftp site.
@@ -105,7 +105,7 @@ Will download the fasta file with the protein sequences, their mapping to a taxi
 #### [Genome Taxonomy Database (GTDB)](https://gtdb.ecogenomic.org/) proteins
 
 ```
-$ CAT_pack download -db gtdb -o path/to/gtdb_data_dir
+$ CAT_pack download --db gtdb -o path/to/gtdb_data_dir
 ```
 
 The files required to build a CAT pack database are provided by the [GTDB downloads page](https://gtdb.ecogenomic.org/downloads).


### PR DESCRIPTION
The program actually wants two dashes in `CAT_pack download --db ...`