### PR TITLE
Bug fix in prepare.py

### DIFF
--- a/CAT_pack/prepare.py
+++ b/CAT_pack/prepare.py
@@ -155,7 +155,7 @@ def make_mmseqs2_database(
 
     try:
         message = "Running command: {0}".format(" ".join(command))
-        give_user_feedback(message, log_file, quiet)
+        shared.give_user_feedback(message, log_file, quiet)
 
         subprocess.check_call(command)
     except:

--- a/CAT_pack/prepare.py
+++ b/CAT_pack/prepare.py
@@ -115,7 +115,7 @@ def make_diamond_database(
 
     try:
         message = "Running command: {0}".format(" ".join(command))
-        give_user_feedback(message, log_file, quiet)
+        shared.give_user_feedback(message, log_file, quiet)
 
         subprocess.check_call(command)
     except:


### PR DESCRIPTION
In the block that constructs the DIAMOND database, there was a small bug in the logging (line 118):

https://github.com/MGXlab/CAT_pack/blob/94f2deeb225be6b034c85c036bdd8783d725fb99/CAT_pack/prepare.py#L116-L125

The bug caused that the prepare workflow stopped with

`ERROR: DIAMOND database could not be created.`

without further details on the cause of the error in the log files.

Prepending the `shared.` in calling the function `give_user_feedback` fixes the bug.